### PR TITLE
Fix bug causing spout dead-locks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>org.xyro</groupId>
     <artifactId>kumulus</artifactId>
-    <version>0.1.40</version>
+    <version>0.1.41</version>
 
     <name>kumulus</name>
     <description>A lightweight, in-process, drop-in replacement for Apache Storm</description>

--- a/src/main/kotlin/org/xyro/kumulus/KumulusAcker.kt
+++ b/src/main/kotlin/org/xyro/kumulus/KumulusAcker.kt
@@ -37,7 +37,7 @@ class KumulusAcker(
     fun startTree(component: KumulusSpout, messageId: Any?) {
         logger.debug { "startTree() -> component: $component, messageId: $messageId" }
         if (messageId == null) {
-            notifySpout(component, messageId, listOf()) {}
+            notifySpout(component, messageId, listOf())
         } else {
             MessageState(component).let { messageState ->
                 synchronized(completeLock) {
@@ -72,9 +72,8 @@ class KumulusAcker(
                                         messageId,
                                         removedState.pendingTasks.map { it.key },
                                         removedState.failedTasks.toList()
-                                    ) {
-                                        decrementPending()
-                                    }
+                                    )
+                                    decrementPending()
                                 }
                             }
                         },
@@ -165,9 +164,8 @@ class KumulusAcker(
                     }
                     val removedState = state.remove(spoutMessageId)
                     if (removedState != null) {
-                        notifySpout(messageState.spout, spoutMessageId, messageState.failedTasks.toList()) {
-                            decrementPending()
-                        }
+                        notifySpout(messageState.spout, spoutMessageId, messageState.failedTasks.toList())
+                        decrementPending()
                     } else {
                         logger.debug { "Race while closing tuple-tree, ignoring duplicate" }
                     }
@@ -193,18 +191,17 @@ class KumulusAcker(
         }
     }
 
-    private fun notifySpout(spout: KumulusSpout, spoutMessageId: Any?, failedTasks: List<Int>, callback: () -> Unit) {
-        this.notifySpout(spout, spoutMessageId, listOf(), failedTasks, callback)
+    private fun notifySpout(spout: KumulusSpout, spoutMessageId: Any?, failedTasks: List<Int>) {
+        this.notifySpout(spout, spoutMessageId, listOf(), failedTasks)
     }
 
     private fun notifySpout(
         spout: KumulusSpout,
         spoutMessageId: Any?,
         timeoutTasks: List<Int>,
-        failedTasks: List<Int>,
-        callback: () -> Unit
+        failedTasks: List<Int>
     ) {
-        emitter.completeMessageProcessing(spout, spoutMessageId, timeoutTasks, failedTasks, callback)
+        emitter.completeMessageProcessing(spout, spoutMessageId, timeoutTasks, failedTasks)
     }
 
     private fun decrementPending() {

--- a/src/main/kotlin/org/xyro/kumulus/KumulusEmitter.kt
+++ b/src/main/kotlin/org/xyro/kumulus/KumulusEmitter.kt
@@ -10,8 +10,7 @@ interface KumulusEmitter {
         spout: KumulusSpout,
         spoutMessageId: Any?,
         timeoutTasks: List<Int>,
-        failedTasks: List<Int>,
-        callback: () -> Unit
+        failedTasks: List<Int>
     )
     fun throwException(t: Throwable)
 }

--- a/src/main/kotlin/org/xyro/kumulus/KumulusTopology.kt
+++ b/src/main/kotlin/org/xyro/kumulus/KumulusTopology.kt
@@ -224,8 +224,7 @@ class KumulusTopology(
         spout: KumulusSpout,
         spoutMessageId: Any?,
         timeoutTasks: List<Int>,
-        failedTasks: List<Int>,
-        callback: () -> Unit
+        failedTasks: List<Int>
     ) {
         spout.queue.add(
             AckMessage(
@@ -233,8 +232,7 @@ class KumulusTopology(
                 spoutMessageId,
                 timeoutTasks.isEmpty() && failedTasks.isEmpty(),
                 timeoutTasks.map { this.taskIdToComponent[it]!!.componentId },
-                failedTasks.map { this.taskIdToComponent[it]!!.componentId },
-                callback
+                failedTasks.map { this.taskIdToComponent[it]!!.componentId }
             )
         )
     }

--- a/src/main/kotlin/org/xyro/kumulus/component/KumulusComponent.kt
+++ b/src/main/kotlin/org/xyro/kumulus/component/KumulusComponent.kt
@@ -85,6 +85,5 @@ class AckMessage(
     val spoutMessageId: Any?,
     val ack: Boolean,
     val timeoutComponents: List<String>,
-    val failedComponents: List<String>,
-    val callback: () -> Unit
+    val failedComponents: List<String>
 ) : KumulusMessage(spout)

--- a/src/main/kotlin/org/xyro/kumulus/component/KumulusSpout.kt
+++ b/src/main/kotlin/org/xyro/kumulus/component/KumulusSpout.kt
@@ -102,7 +102,6 @@ class KumulusSpout(
             } else {
                 fail(ackMessage.spoutMessageId, ackMessage.timeoutComponents, ackMessage.failedComponents)
             }
-            ackMessage.callback()
         }.let {
             if (it == null && isReady.get()) {
                 if (acker.waitForSpoutAvailability()) {

--- a/src/test/kotlin/org/xyro/kumulus/TestAnchoringBehavior.kt
+++ b/src/test/kotlin/org/xyro/kumulus/TestAnchoringBehavior.kt
@@ -46,7 +46,10 @@ class TestAnchoringBehavior {
         kumulusTopology.stop()
 
         logger.info { "Ran ${calledCount.get()} times" }
-        assertTrue { calledCount.get() > 10 }
+        assertTrue { calledCount.get() > 1000 }
+        val avgDelay = sumWait.get() / calledCount.get().toDouble()
+        logger.info { "Avg delay: ${avgDelay}ms" }
+        assertTrue { avgDelay < 10 }
     }
 
     class LatencyDeltaSpout : DummySpout({

--- a/src/test/kotlin/org/xyro/kumulus/TestMultipleSpoutsMaxPendingLimit.kt
+++ b/src/test/kotlin/org/xyro/kumulus/TestMultipleSpoutsMaxPendingLimit.kt
@@ -81,12 +81,13 @@ class TestMultipleSpoutsMaxPendingLimit {
     }
 
     class TestSpout : DummySpout({ it.declare(Fields("id")) }) {
-        private var count = 0
-
-        override fun fail(msgId: Any?) {
-        }
+        override fun fail(msgId: Any?) {}
 
         override fun ack(msgId: Any?) {
+            // Emitting from the spout's ack method is supported behavior in Storm. The following emit() was added to
+            // the test to verify this behavior in the multi-spout scenario
+            val messageId = UUID.randomUUID().toString()
+            collector.emit(listOf(messageId), messageId)
         }
 
         override fun nextTuple() {


### PR DESCRIPTION
Fixing an issue where calling collector.emit() from a spout's ack/fail method can cause topology to dead-lock. Fix involved reverting a previous PR (https://github.com/reembs/kumulus/pull/45).

Note that from now on Kumulus does not guarantee max-spout-pending concurrency between the Spout's `ack()`/`fail()` and `nextTuple()`. That means that while it is not possible to breach max-spout-pending before all bolts in the tuple-tree had responded, the following scenario is possible:

1. All bolts responded
2. `nextTuple()` is called before `ack()`/`fail()`, seemingly breaching the guarantee from the spout's
perspective
3. `ack()`/`fail()` is called

Note that this can cause the current pending tuples num, as monitored from the Spout's perspective, to drift from max-spout-pending by much more than 1 in certain cases.