### PR TITLE
Add MDC logging context propagation across spout/bolt chain

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,13 @@
             <version>2.2.2</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>2.8.2</version>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/kotlin/org/xyro/kumulus/KumulusTopology.kt
+++ b/src/main/kotlin/org/xyro/kumulus/KumulusTopology.kt
@@ -4,6 +4,7 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import org.apache.storm.Config
 import org.apache.storm.Constants
 import org.apache.storm.tuple.Tuple
+import org.slf4j.MDC
 import org.xyro.kumulus.collector.KumulusBoltCollector
 import org.xyro.kumulus.collector.KumulusSpoutCollector
 import org.xyro.kumulus.component.AckMessage
@@ -299,7 +300,12 @@ class KumulusTopology(
                             throw RuntimeException("Execute message got to a spout '${c.componentId}', this shouldn't happen.")
                         }
                         callBusyHook(c, message)
-                        c.execute(message.tuple)
+                        MDC.setContextMap(message.tuple.loggingContext + mapOf("component" to c.componentId))
+                        try {
+                            c.execute(message.tuple)
+                        } finally {
+                            MDC.clear()
+                        }
                     }
                     else ->
                         throw UnsupportedOperationException("Operation of type ${c.javaClass.canonicalName} is unsupported")

--- a/src/main/kotlin/org/xyro/kumulus/KumulusTopology.kt
+++ b/src/main/kotlin/org/xyro/kumulus/KumulusTopology.kt
@@ -300,7 +300,13 @@ class KumulusTopology(
                             throw RuntimeException("Execute message got to a spout '${c.componentId}', this shouldn't happen.")
                         }
                         callBusyHook(c, message)
-                        MDC.setContextMap(message.tuple.loggingContext + mapOf("component" to c.componentId))
+                        MDC.setContextMap(
+                            message.tuple.loggingContext +
+                                mapOf(
+                                    "component" to c.componentId,
+                                    "component_index" to c.taskIndex.toString(),
+                                ),
+                        )
                         try {
                             c.execute(message.tuple)
                         } finally {

--- a/src/main/kotlin/org/xyro/kumulus/KumulusTuple.kt
+++ b/src/main/kotlin/org/xyro/kumulus/KumulusTuple.kt
@@ -10,6 +10,7 @@ class KumulusTuple(
     streamId: String,
     tuple: List<Any>,
     messageId: Any?,
+    val loggingContext: Map<String, String> = emptyMap(),
 ) {
     private val spoutMessageId = messageId
 

--- a/src/main/kotlin/org/xyro/kumulus/collector/KumulusCollector.kt
+++ b/src/main/kotlin/org/xyro/kumulus/collector/KumulusCollector.kt
@@ -4,6 +4,7 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import org.apache.storm.grouping.CustomStreamGrouping
 import org.apache.storm.tuple.Tuple
 import org.apache.storm.utils.Utils
+import org.slf4j.MDC
 import org.xyro.kumulus.KumulusAcker
 import org.xyro.kumulus.KumulusEmitter
 import org.xyro.kumulus.KumulusTuple
@@ -35,6 +36,17 @@ abstract class KumulusCollector<T : KumulusComponent>(
         )
     }
 
+    private fun buildLoggingContext(
+        streamId: String?,
+        messageId: Any?,
+    ): Map<String, String> {
+        val ctx = (MDC.getCopyOfContextMap() ?: emptyMap()).toMutableMap()
+        ctx["component"] = component.componentId
+        ctx["stream_id"] = streamId ?: Utils.DEFAULT_STREAM_ID
+        messageId?.let { ctx["message_id"] = it.toString() }
+        return ctx
+    }
+
     private fun componentEmit(
         streamId: String?,
         tuple: MutableList<Any>,
@@ -42,6 +54,7 @@ abstract class KumulusCollector<T : KumulusComponent>(
     ): MutableList<Int> {
         val ret = mutableListOf<Int>()
 
+        val loggingContext = buildLoggingContext(streamId, messageId)
         var executes: List<Pair<KumulusComponent, KumulusTuple>> = listOf()
 
         component.groupingStateMap[streamId]?.let { streamTargets: Map<String, CustomStreamGrouping> ->
@@ -54,7 +67,14 @@ abstract class KumulusCollector<T : KumulusComponent>(
                 executes +=
                     emitToInstance
                         .map { destComponent ->
-                            val kumulusTuple = KumulusTuple(component, streamId ?: Utils.DEFAULT_STREAM_ID, tuple, messageId)
+                            val kumulusTuple =
+                                KumulusTuple(
+                                    component,
+                                    streamId ?: Utils.DEFAULT_STREAM_ID,
+                                    tuple,
+                                    messageId,
+                                    loggingContext,
+                                )
                             acker.expandTrees(component, destComponent.taskId, kumulusTuple)
                             destComponent to kumulusTuple
                         }.toList()

--- a/src/main/kotlin/org/xyro/kumulus/collector/KumulusCollector.kt
+++ b/src/main/kotlin/org/xyro/kumulus/collector/KumulusCollector.kt
@@ -42,6 +42,7 @@ abstract class KumulusCollector<T : KumulusComponent>(
     ): Map<String, String> {
         val ctx = (MDC.getCopyOfContextMap() ?: emptyMap()).toMutableMap()
         ctx["component"] = component.componentId
+        ctx["component_index"] = component.taskIndex.toString()
         ctx["stream_id"] = streamId ?: Utils.DEFAULT_STREAM_ID
         messageId?.let { ctx["message_id"] = it.toString() }
         return ctx

--- a/src/main/kotlin/org/xyro/kumulus/component/KumulusComponent.kt
+++ b/src/main/kotlin/org/xyro/kumulus/component/KumulusComponent.kt
@@ -32,6 +32,7 @@ abstract class KumulusComponent(
 
     val componentId = context.thisComponentId!!
     val taskId = context.thisTaskId
+    val taskIndex = context.thisTaskIndex
 
     fun prepare() {
         val groupingStateMap: MutableMap<String, MutableMap<String, CustomStreamGrouping>> = mutableMapOf()

--- a/src/main/kotlin/org/xyro/kumulus/component/KumulusSpout.kt
+++ b/src/main/kotlin/org/xyro/kumulus/component/KumulusSpout.kt
@@ -4,6 +4,7 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import org.apache.storm.spout.SpoutOutputCollector
 import org.apache.storm.task.TopologyContext
 import org.apache.storm.topology.IRichSpout
+import org.slf4j.MDC
 import org.xyro.kumulus.KumulusAcker
 import org.xyro.kumulus.KumulusTopology
 import org.xyro.kumulus.collector.KumulusSpoutCollector
@@ -112,7 +113,12 @@ class KumulusSpout(
                         if (inUse.compareAndSet(false, true)) {
                             try {
                                 if (isReady.get()) {
-                                    nextTuple()
+                                    MDC.put("component", componentId)
+                                    try {
+                                        nextTuple()
+                                    } finally {
+                                        MDC.clear()
+                                    }
                                 }
                             } finally {
                                 inUse.set(false)

--- a/src/main/kotlin/org/xyro/kumulus/component/KumulusSpout.kt
+++ b/src/main/kotlin/org/xyro/kumulus/component/KumulusSpout.kt
@@ -114,6 +114,7 @@ class KumulusSpout(
                             try {
                                 if (isReady.get()) {
                                     MDC.put("component", componentId)
+                                    MDC.put("component_index", taskIndex.toString())
                                     try {
                                         nextTuple()
                                     } finally {

--- a/src/test/kotlin/org/xyro/kumulus/TestLoggingContext.kt
+++ b/src/test/kotlin/org/xyro/kumulus/TestLoggingContext.kt
@@ -1,0 +1,303 @@
+package org.xyro.kumulus
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.apache.logging.log4j.Level
+import org.apache.logging.log4j.LogManager
+import org.apache.logging.log4j.core.LoggerContext
+import org.apache.logging.log4j.test.appender.ListAppender
+import org.apache.storm.Config
+import org.apache.storm.task.OutputCollector
+import org.apache.storm.task.TopologyContext
+import org.apache.storm.topology.IRichBolt
+import org.apache.storm.topology.OutputFieldsDeclarer
+import org.apache.storm.tuple.Fields
+import org.apache.storm.tuple.Tuple
+import org.junit.Test
+import org.slf4j.MDC
+import org.xyro.kumulus.topology.KumulusTopologyBuilder
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.TimeUnit
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+
+class TestLoggingContext {
+    companion object {
+        // Accessed statically by inner classes — not serialized as bolt/spout instance fields.
+        val signal = LinkedBlockingQueue<Unit>()
+        val spoutSignal = LinkedBlockingQueue<Unit>()
+    }
+
+    private fun awaitSignal() = signal.poll(5, TimeUnit.SECONDS) ?: error("timeout waiting for bolt execution")
+
+    private fun awaitSpoutSignal() = spoutSignal.poll(5, TimeUnit.SECONDS) ?: error("timeout waiting for spout signal")
+
+    private fun withListAppender(block: (ListAppender) -> Unit) {
+        val appender = ListAppender("test-${System.nanoTime()}")
+        appender.start()
+        val ctx = LogManager.getContext(false) as LoggerContext
+        val config = ctx.configuration
+        config.addAppender(appender)
+        config.rootLogger.addAppender(appender, Level.TRACE, null)
+        ctx.updateLoggers()
+        try {
+            block(appender)
+        } finally {
+            config.rootLogger.removeAppender(appender.name)
+            appender.stop()
+            ctx.updateLoggers()
+        }
+    }
+
+    private fun boltEvent(appender: ListAppender) = appender.events.last { "bolt-execute" in it.message.formattedMessage }
+
+    @Test
+    fun testFrameworkKeysPopulatedOnBolt() {
+        signal.clear()
+        withListAppender { appender ->
+            val builder = KumulusTopologyBuilder()
+            val config = mutableMapOf<String, Any>(Config.TOPOLOGY_MAX_SPOUT_PENDING to 1L)
+
+            builder.setSpout(
+                "my-spout",
+                object : DummySpout({ it.declare(Fields("val")) }) {
+                    private var emitted = false
+
+                    override fun nextTuple() {
+                        if (!emitted) {
+                            emitted = true
+                            collector.emit(listOf("data"), "msg-42")
+                        }
+                    }
+                },
+            )
+            builder.setBolt("my-bolt", SignalingBolt()).noneGrouping("my-spout")
+
+            val topology = KumulusStormTransformer.initializeTopology(builder.createTopology(), config, "test")
+            topology.prepare(10, TimeUnit.SECONDS)
+            topology.start(false)
+            awaitSignal()
+            topology.stop()
+
+            val event = boltEvent(appender)
+            assertEquals("my-bolt", event.contextMap["component"])
+            assertEquals("default", event.contextMap["stream_id"])
+            assertEquals("msg-42", event.contextMap["message_id"])
+        }
+    }
+
+    @Test
+    fun testCustomKeyPropagatesFromSpoutToBolt() {
+        signal.clear()
+        withListAppender { appender ->
+            val builder = KumulusTopologyBuilder()
+            val config = mutableMapOf<String, Any>(Config.TOPOLOGY_MAX_SPOUT_PENDING to 1L)
+
+            builder.setSpout(
+                "spout",
+                object : DummySpout({ it.declare(Fields("val")) }) {
+                    private var emitted = false
+
+                    override fun nextTuple() {
+                        if (!emitted) {
+                            emitted = true
+                            MDC.put("request_id", "req-999")
+                            collector.emit(listOf("data"), "msg-1")
+                        }
+                    }
+                },
+            )
+            builder.setBolt("bolt", SignalingBolt()).noneGrouping("spout")
+
+            val topology = KumulusStormTransformer.initializeTopology(builder.createTopology(), config, "test")
+            topology.prepare(10, TimeUnit.SECONDS)
+            topology.start(false)
+            awaitSignal()
+            topology.stop()
+
+            assertEquals("req-999", boltEvent(appender).contextMap["request_id"])
+        }
+    }
+
+    @Test
+    fun testMdcClearedBetweenBoltExecutions() {
+        signal.clear()
+        withListAppender { appender ->
+            val builder = KumulusTopologyBuilder()
+            val config = mutableMapOf<String, Any>(Config.TOPOLOGY_MAX_SPOUT_PENDING to 2L)
+
+            builder.setSpout(
+                "spout",
+                object : DummySpout({ it.declare(Fields("val")) }) {
+                    private var count = 0
+
+                    override fun nextTuple() {
+                        count++
+                        when (count) {
+                            1 -> {
+                                MDC.put("unique_key", "only-in-msg1")
+                                collector.emit(listOf("v"), "msg-1")
+                            }
+                            2 -> collector.emit(listOf("v"), "msg-2")
+                        }
+                    }
+                },
+            )
+            builder.setBolt("bolt", SignalingBolt()).noneGrouping("spout")
+
+            val topology = KumulusStormTransformer.initializeTopology(builder.createTopology(), config, "test")
+            topology.prepare(10, TimeUnit.SECONDS)
+            topology.start(false)
+            awaitSignal()
+            awaitSignal()
+            topology.stop()
+
+            val eventForMsg2 =
+                appender.events
+                    .filter { "bolt-execute" in it.message.formattedMessage }
+                    .first { it.contextMap["message_id"] == "msg-2" }
+            assertNull(eventForMsg2.contextMap["unique_key"], "unique_key from msg-1 must not leak into msg-2 execution")
+        }
+    }
+
+    @Test
+    fun testMdcClearedBetweenSpoutNextTupleCalls() {
+        spoutSignal.clear()
+        withListAppender { appender ->
+            val builder = KumulusTopologyBuilder()
+            val config = mutableMapOf<String, Any>(Config.TOPOLOGY_MAX_SPOUT_PENDING to 5L)
+
+            builder.setSpout("spout", MdcLeakTestSpout())
+            builder.setBolt("bolt", DummyBolt()).noneGrouping("spout")
+
+            val topology = KumulusStormTransformer.initializeTopology(builder.createTopology(), config, "test")
+            topology.prepare(10, TimeUnit.SECONDS)
+            topology.start(false)
+            awaitSpoutSignal()
+            topology.stop()
+
+            val event = appender.events.last { "spout-second-call" in it.message.formattedMessage }
+            assertFalse(
+                event.contextMap.containsKey("spout_key"),
+                "spout_key set during first nextTuple must not leak into second nextTuple call",
+            )
+        }
+    }
+
+    @Test
+    fun testContextFlowsThroughBoltChain() {
+        signal.clear()
+        withListAppender { appender ->
+            val builder = KumulusTopologyBuilder()
+            val config = mutableMapOf<String, Any>(Config.TOPOLOGY_MAX_SPOUT_PENDING to 1L)
+
+            builder.setSpout(
+                "spout",
+                object : DummySpout({ it.declare(Fields("val")) }) {
+                    private var emitted = false
+
+                    override fun nextTuple() {
+                        if (!emitted) {
+                            emitted = true
+                            MDC.put("request_id", "chain-req")
+                            collector.emit(listOf("v"), "chain-msg")
+                        }
+                    }
+                },
+            )
+            builder.setBolt("bolt1", HopAnnotatingBolt()).noneGrouping("spout")
+            builder.setBolt("bolt2", SignalingBolt()).noneGrouping("bolt1")
+
+            val topology = KumulusStormTransformer.initializeTopology(builder.createTopology(), config, "test")
+            topology.prepare(10, TimeUnit.SECONDS)
+            topology.start(false)
+            awaitSignal()
+            topology.stop()
+
+            val event = boltEvent(appender)
+            assertEquals("chain-req", event.contextMap["request_id"])
+            assertEquals("1", event.contextMap["hop_count"])
+            assertEquals("bolt2", event.contextMap["component"])
+            assertEquals("chain-msg", event.contextMap["message_id"])
+        }
+    }
+
+    // Logs "bolt-execute" and signals via companion queue — context on the log event is what we assert.
+    class SignalingBolt : IRichBolt {
+        private lateinit var collector: OutputCollector
+
+        override fun prepare(
+            conf: MutableMap<Any?, Any?>?,
+            ctx: TopologyContext?,
+            c: OutputCollector?,
+        ) {
+            collector = c!!
+        }
+
+        override fun execute(input: Tuple) {
+            logger.info("bolt-execute")
+            signal.offer(Unit)
+            collector.ack(input)
+        }
+
+        override fun cleanup() = Unit
+
+        override fun getComponentConfiguration() = mutableMapOf<String, Any>()
+
+        override fun declareOutputFields(d: OutputFieldsDeclarer) = Unit
+
+        companion object {
+            private val logger = KotlinLogging.logger {}
+        }
+    }
+
+    // Adds hop_count=1 to MDC and emits downstream with anchoring.
+    class HopAnnotatingBolt : IRichBolt {
+        private lateinit var collector: OutputCollector
+
+        override fun prepare(
+            conf: MutableMap<Any?, Any?>?,
+            ctx: TopologyContext?,
+            c: OutputCollector?,
+        ) {
+            collector = c!!
+        }
+
+        override fun execute(input: Tuple) {
+            MDC.put("hop_count", "1")
+            collector.emit(listOf(input), input.values)
+            collector.ack(input)
+        }
+
+        override fun cleanup() = Unit
+
+        override fun getComponentConfiguration() = mutableMapOf<String, Any>()
+
+        override fun declareOutputFields(d: OutputFieldsDeclarer) {
+            d.declare(Fields("val"))
+        }
+    }
+
+    // First nextTuple sets spout_key and emits; second logs "spout-second-call" and signals.
+    class MdcLeakTestSpout : DummySpout({ it.declare(Fields("val")) }) {
+        private var count = 0
+
+        override fun nextTuple() {
+            count++
+            when (count) {
+                1 -> {
+                    MDC.put("spout_key", "from-first-call")
+                    collector.emit(listOf("v"), "msg-1")
+                }
+                2 -> {
+                    logger.info("spout-second-call")
+                    spoutSignal.offer(Unit)
+                }
+            }
+        }
+
+        companion object {
+            private val logger = KotlinLogging.logger {}
+        }
+    }
+}

--- a/src/test/kotlin/org/xyro/kumulus/TestLoggingContext.kt
+++ b/src/test/kotlin/org/xyro/kumulus/TestLoggingContext.kt
@@ -81,6 +81,7 @@ class TestLoggingContext {
 
             val event = boltEvent(appender)
             assertEquals("my-bolt", event.contextMap["component"])
+            assertEquals("0", event.contextMap["component_index"])
             assertEquals("default", event.contextMap["stream_id"])
             assertEquals("msg-42", event.contextMap["message_id"])
         }
@@ -181,6 +182,7 @@ class TestLoggingContext {
                 event.contextMap.containsKey("spout_key"),
                 "spout_key set during first nextTuple must not leak into second nextTuple call",
             )
+            assertEquals("0", event.contextMap["component_index"])
         }
     }
 


### PR DESCRIPTION
## Summary

- Captures MDC snapshot at emit time (`component`, `stream_id`, `message_id` + any user-set keys) and stores it on `KumulusTuple.loggingContext`
- Restores MDC before bolt execution (overriding `component` with the current bolt name) and clears after — preventing cross-message leakage on reused threads
- Spout thread sets `component` around each `nextTuple()` call with the same clear pattern

## Usage

Spouts and bolts can attach custom context by calling `MDC.put(key, value)` before `collector.emit(...)` — no API changes needed. Keys propagate through the entire bolt chain automatically.

```kotlin
// in spout nextTuple()
MDC.put("request_id", requestId)
collector.emit(values, messageId)

// in any downstream bolt, logs will automatically include:
// component=<bolt-name>, stream_id=..., message_id=..., request_id=...
```

## Test plan

- `testFrameworkKeysPopulatedOnBolt` — `component`, `stream_id`, `message_id` present on bolt log events
- `testCustomKeyPropagatesFromSpoutToBolt` — user MDC key set by spout reaches bolt log event
- `testMdcClearedBetweenBoltExecutions` — key from msg-1 absent on msg-2 log event (no thread leakage)
- `testMdcClearedBetweenSpoutNextTupleCalls` — key from first `nextTuple` absent on second call
- `testContextFlowsThroughBoltChain` — spout key + bolt1-added key both visible on bolt2 log event

Tests use Log4j2 `ListAppender` to assert context keys appear on actual emitted `LogEvent` objects.